### PR TITLE
Update requirements to be alittle less repetitive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "cwp/cwp-recipe-core": "2.x-dev",
         "cwp/cwp": "2.x-dev",
         "cwp/cwp-pdfexport": "1.x-dev",
-        "silverstripe/html5": "2.x-dev",
-        "symbiote/silverstripe-gridfieldextensions": "3.1.x-dev"
+        "silverstripe/html5": "2.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
The `symbiote/silverstripe-gridfieldextensions` is now (as of recently) a
requirement of `cwp/cwp` Thus it is no longer necessary to list it here
directly, as all modules (and modules of recipes) will pull in their own
requirements, listing an individual upstream requirement that this recipe
does not directly depend on is unnecessary.

Reference: https://github.com/silverstripe/cwp/pull/46#issuecomment-366838959