### PR TITLE
FIX Add proxy configuration for embedded cURL requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "phpunit/phpunit": "^5.7"
     },
     "extra": {
-        "project-files": []
+        "project-files": [
+            "mysite/*"
+        ]
     },
     "config": {
         "process-timeout": 600

--- a/mysite/_config/oembed.yml
+++ b/mysite/_config/oembed.yml
@@ -1,0 +1,17 @@
+---
+Name: cwpoembedconfig
+Except:
+  environment: dev
+Only:
+  EnvVarSet: SS_OUTBOUND_PROXY
+---
+SilverStripe\Core\Injector\Injector:
+  # Configure the CWP proxy if defined
+  Embed\Http\DispatcherInterface:
+    class: Embed\Http\CurlDispatcher
+    constructor:
+      config:
+        # CURLOPT_PROXY = 10004
+        10004: '`SS_OUTBOUND_PROXY`'
+        # CURLOPT_PROXYPORT = 59
+        59: '`SS_OUTBOUND_PROXY_PORT`'


### PR DESCRIPTION
Adds configuration to use the SilverStripe proxy env vars if set in Embed requests via cURL

Requires https://github.com/silverstripe/silverstripe-asset-admin/pull/793 and https://github.com/silverstripe/silverstripe-framework/pull/8192